### PR TITLE
:recycle: Refactor: 게시글, 댓글 삭제 권한 로직 변경

### DIFF
--- a/src/crew/page/post/controller/post.controller.js
+++ b/src/crew/page/post/controller/post.controller.js
@@ -455,7 +455,7 @@ export const deleteCrewPost = async (req, res, next) => {
       }
     };
     #swagger.responses[400] = {
-      description: "특정 크루 특정 게시글 수정 실패 응답",
+      description: "특정 크루 특정 게시글 삭제 실패 응답",
       content: {
         "application/json": {
           schema: {
@@ -843,12 +843,7 @@ export const deleteCrewPostComment = async (req, res, next) => {
               data: {
                 type: "string", example: 
                 {
-                  "commentId": 3,
-                  "content": "삭제된 댓글의 내용입니다.",
-                  "nickname": "홍길동",
-                  "createdAt": "2025-07-18 02:04:54.410",
-                  "nickname": "길동이",
-                  "image": "profile.jpg",
+                  "success" : true
                 }
               }
             }
@@ -881,5 +876,5 @@ export const deleteCrewPostComment = async (req, res, next) => {
   */
   // #endregion
 
-  res.status(StatusCodes.OK).success(response);
+  res.status(StatusCodes.OK).success({ success: true });
 };

--- a/src/crew/page/post/service/post.service.js
+++ b/src/crew/page/post/service/post.service.js
@@ -162,7 +162,7 @@ export const deleteCrewPost = async ({ userId, crewId, postId }) => {
 		if (!crewMember) {
 			throw new baseError.NotCrewMemberError("크루 멤버에 속하지 않은 유저입니다.", { userId });
 		}
-		if (isExistPost.crewMemberId !== userId && crewMember.role !== 2) {
+		if (isExistPost.crewMemberId !== userId && crewMember.role === 0) {
 			throw new baseError.PermissionDeniedError("권한이 없는 유저입니다.", { userId });
 		}
 
@@ -350,7 +350,7 @@ export const deleteCrewPostComment = async ({ crewId, postId, userId, commentId 
 		if (!crewMember) {
 			throw new baseError.NotCrewMemberError("크루 멤버에 속하지 않은 유저입니다.", { userId });
 		}
-		if (isExistComment.crewMemberId !== crewMember.id && crewMember.role !== 2) {
+		if (isExistComment.crewMemberId !== crewMember.id && crewMember.role === 0) {
 			throw new baseError.PermissionDeniedError("권한이 없는 유저입니다.", { userId });
 		}
 


### PR DESCRIPTION
## 📌 PR 요약 (하나 이상 선택해주세요)

- [ ] 게시글, 댓글 삭제 권한 로직 변경

---

## 💡 주요 변경사항

- 운영진부터 게시글, 댓글 삭제가 가능하도록 변경

## 🔍 관련 이슈

- #

---

## 🌿 브랜치 정보

- 병합 대상 브랜치: develop
- 현재 작업 브랜치: crew-page-post

---

## 🧪 테스트 방법

- 운영진으로 다른 유저의 게시글, 댓글 삭제 가능하도록 하게 하기

## ⚠️ 주의사항

-
