### PR TITLE
:sparkles: Feat: 크루 게시글 좋아요, 댓글 알림 기능 적용

### DIFF
--- a/src/crew/page/post/repository/post.repository.js
+++ b/src/crew/page/post/repository/post.repository.js
@@ -546,6 +546,11 @@ export const isExistPost = async ({ postId }) => {
 					crewMember: {
 						select: {
 							role: true,
+							user: {
+								select: {
+									id: true
+								}
+							}
 						}
 					}
 				}


### PR DESCRIPTION
## 📌 PR 요약 (하나 이상 선택해주세요)

- [ ] 기능 추가 : 크루 게시글 좋아요, 댓글 알림 기능 적용

---

## 💡 주요 변경사항

- 크루원이 게시글 좋아요, 댓글 작성시 게시글의 주인 크루원에게 알림 전송 기능 적용

## 🔍 관련 이슈

- #

---

## 🌿 브랜치 정보

- 병합 대상 브랜치: develop
- 현재 작업 브랜치: feature/darong/crew-page-post

---

## 🧪 테스트 방법

- swagger에서 댓글 및 좋아요

## ⚠️ 주의사항

-
